### PR TITLE
Enable legacy path

### DIFF
--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -253,7 +253,12 @@ static EVP_PKEY_CTX *int_ctx_new(OSSL_LIB_CTX *libctx,
         pmeth = EVP_PKEY_meth_find(id);
     else
 # endif
+        /* Try legacy pmeth unconditionally in UEFI system due to memory limit. */
+#ifdef OPENSSL_SYS_UEFI
+        app_pmeth = pmeth = EVP_PKEY_meth_find(id);
+#else
         app_pmeth = pmeth = evp_pkey_meth_find_added_by_application(id);
+#endif
 
     /* END legacy */
 #endif /* FIPS_MODULE */

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -406,18 +406,21 @@ static int x509_pubkey_decode(EVP_PKEY **ppkey, const X509_PUBKEY *key)
     int nid;
 
     nid = OBJ_obj2nid(key->algor->algorithm);
+    /* Try legacy ameth path unconditionally in UEFI system due to memory limit. */
+#ifndef OPENSSL_SYS_UEFI
     if (!key->flag_force_legacy) {
-#ifndef OPENSSL_NO_ENGINE
+# ifndef OPENSSL_NO_ENGINE
         ENGINE *e = NULL;
 
         e = ENGINE_get_pkey_meth_engine(nid);
         if (e == NULL)
             return 0;
         ENGINE_finish(e);
-#else
+# else
         return 0;
-#endif
+# endif
     }
+#endif
 
     pkey = EVP_PKEY_new();
     if (pkey == NULL) {


### PR DESCRIPTION
Always try legacy path in x509_pubkey_decode() and int_ctx_new().
This allows users who are sensitive to size to use legacy ameth/pmeth,
and removes the related providers.

Will reduce ~100KB binaries size when building crypto library in EDK2(original size is 1578KB).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
